### PR TITLE
Add Bazel workspace validation 

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -49,6 +49,7 @@ py_bazel_mcp/
 
 ### 4. `util.py` - Configuration
 - `which_bazel()` - Detects Bazel/Bazelisk executable
+- `validate_bazel_workspace()` - Validates Bazel workspace presence
 - `DEFAULT_KINDS` - Configurable target kinds to discover
 
 ## MCP Tools Exposed
@@ -98,7 +99,7 @@ Use Settings → MCP Servers → Add Custom Server with generated config.
 
 ## How It Works
 
-1. **Startup**: Server validates Bazel workspace (WORKSPACE or MODULE.bazel)
+1. **Startup**: Server validates Bazel workspace (requires WORKSPACE, WORKSPACE.bazel, or MODULE.bazel). Exits with error if not found.
 2. **Discovery**: On first `bazel_list_targets` call, queries all target kinds
 3. **Caching**: Results cached in memory; refresh with `refresh: true`
 4. **Execution**: Bazel commands run via `asyncio.create_subprocess_exec`
@@ -177,6 +178,11 @@ print(asyncio.run(discover_targets('/path/to/repo')))
 
 ### "No module named 'mcp'"
 - Solution: `source .venv/bin/activate && pip install -e .`
+
+### "Not a valid Bazel repository"
+- Server requires WORKSPACE, WORKSPACE.bazel, or MODULE.bazel in the `--repo` directory
+- Check the path provided to `--repo` argument
+- Server will exit with error code 1 if workspace files are not found
 
 ### "bazel query failed"
 - Ensure WORKSPACE/MODULE.bazel exists

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -133,6 +133,12 @@ source .venv/bin/activate
 pip install -e .
 ```
 
+### "Not a valid Bazel repository"
+The server requires a valid Bazel workspace. Ensure your `--repo` path contains one of:
+- `WORKSPACE`
+- `WORKSPACE.bazel`
+- `MODULE.bazel`
+
 ### "Bazel not found"
 Install Bazelisk:
 ```bash
@@ -144,7 +150,7 @@ sudo mv bazel /usr/local/bin/bazel
 ### Server not responding in Warp/VS Code/Cursor
 1. Check the MCP server logs in your editor
 2. Verify `working_directory` and `PYTHONPATH` are set correctly
-3. Ensure the `--repo` path points to a valid Bazel workspace
+3. Ensure the `--repo` path points to a valid Bazel workspace (contains WORKSPACE or MODULE.bazel)
 4. Restart your editor
 
 ---

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ sudo mv bazelisk /usr/local/bin/bazel
 | Issue | Solution |
 |-------|----------|
 | "No module named 'mcp'" | Install with `pip install bazel-mcp` |
+| "Not a valid Bazel repository" | The server must be run from a directory containing `WORKSPACE`, `WORKSPACE.bazel`, or `MODULE.bazel`. Check your `--repo` path. |
 | "bazel query failed" | Ensure you're in a Bazel workspace (has `WORKSPACE` or `MODULE.bazel`) |
 | Editor not detecting server | Restart editor after configuration |
 | Logs not streaming | Add `--verbose_failures` flag to see detailed output |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bazel-mcp"
-version = "1.0.2"
+version = "1.0.3"
 description = "MCP server exposing Bazel build/run/test/query as tools"
 requires-python = ">=3.10"
 authors = [{ name = "Sandeep Menon" }]
@@ -8,6 +8,11 @@ readme = "README.md"
 license = { text = "MIT" }
 dependencies = [
   "mcp>=1.2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0.0",
 ]
 
 [project.scripts]

--- a/src/bazel_mcp/server.py
+++ b/src/bazel_mcp/server.py
@@ -16,6 +16,7 @@ from mcp.types import (
 
 from .bazel import run_query, run_build, run_binary, run_test
 from .targets import discover_targets, TargetList
+from .util import validate_bazel_workspace
 
 
 def tool(name: str, description: str, schema: Dict[str, Any]) -> Tool:
@@ -335,19 +336,16 @@ def main():
     # Validate repo path
     repo_root = os.path.abspath(args.repo)
     if not os.path.isdir(repo_root):
-        print(f"Error: {repo_root} is not a valid directory")
+        print(f"Error: {repo_root} is not a valid directory", flush=True)
         return 1
     
     # Check for WORKSPACE or MODULE.bazel file
-    workspace_file = os.path.join(repo_root, "WORKSPACE")
-    workspace_bazel = os.path.join(repo_root, "WORKSPACE.bazel")
-    module_bazel = os.path.join(repo_root, "MODULE.bazel")
-    
-    if not (os.path.exists(workspace_file) or 
-            os.path.exists(workspace_bazel) or 
-            os.path.exists(module_bazel)):
-        print(f"Warning: No WORKSPACE or MODULE.bazel file found in {repo_root}")
-        print("This may not be a valid Bazel repository.")
+    if not validate_bazel_workspace(repo_root):
+        print(f"Error: Not a valid Bazel repository.", flush=True)
+        print(f"No WORKSPACE or MODULE.bazel file found in {repo_root}", flush=True)
+        print("\nPlease run this server from a Bazel workspace root directory.", flush=True)
+        print("Expected files: WORKSPACE, WORKSPACE.bazel, or MODULE.bazel", flush=True)
+        return 1
     
     print(f"Starting Bazel MCP server for: {repo_root}", flush=True)
     

--- a/src/bazel_mcp/util.py
+++ b/src/bazel_mcp/util.py
@@ -16,6 +16,25 @@ def which_bazel() -> str:
     """
     return os.environ.get("BAZEL_PATH") or os.environ.get("BAZELISK") or "bazel"
 
+def validate_bazel_workspace(repo_root: str) -> bool:
+    """
+    Validate that a directory is a Bazel workspace.
+    
+    Checks for the presence of WORKSPACE, WORKSPACE.bazel, or MODULE.bazel files.
+    
+    Args:
+        repo_root: Path to check for Bazel workspace files
+        
+    Returns:
+        bool: True if the directory contains Bazel workspace files, False otherwise
+    """
+    workspace_files = [
+        os.path.join(repo_root, "WORKSPACE"),
+        os.path.join(repo_root, "WORKSPACE.bazel"),
+        os.path.join(repo_root, "MODULE.bazel"),
+    ]
+    return any(os.path.exists(f) for f in workspace_files)
+
 # Default target kinds to discover in Bazel repositories
 DEFAULT_KINDS = (
     "cc_library", 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for bazel-mcp package."""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,46 @@
+"""Tests for utility functions."""
+import os
+import tempfile
+import pytest
+from bazel_mcp.util import validate_bazel_workspace
+
+
+def test_validate_bazel_workspace_with_workspace():
+    """Test validation with WORKSPACE file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = os.path.join(tmpdir, "WORKSPACE")
+        with open(workspace, "w") as f:
+            f.write("# Bazel workspace")
+        
+        assert validate_bazel_workspace(tmpdir) is True
+
+
+def test_validate_bazel_workspace_with_workspace_bazel():
+    """Test validation with WORKSPACE.bazel file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        workspace = os.path.join(tmpdir, "WORKSPACE.bazel")
+        with open(workspace, "w") as f:
+            f.write("# Bazel workspace")
+        
+        assert validate_bazel_workspace(tmpdir) is True
+
+
+def test_validate_bazel_workspace_with_module_bazel():
+    """Test validation with MODULE.bazel file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        module = os.path.join(tmpdir, "MODULE.bazel")
+        with open(module, "w") as f:
+            f.write("# Bazel module")
+        
+        assert validate_bazel_workspace(tmpdir) is True
+
+
+def test_validate_bazel_workspace_without_files():
+    """Test validation fails without any Bazel workspace files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        assert validate_bazel_workspace(tmpdir) is False
+
+
+def test_validate_bazel_workspace_nonexistent_directory():
+    """Test validation with non-existent directory."""
+    assert validate_bazel_workspace("/path/that/does/not/exist") is False


### PR DESCRIPTION
 Added `validate_bazel_workspace()` function to check for required workspace files. Updated server error messages and documentation in PROJECT_OVERVIEW.md, QUICKSTART.md, and README.md to clarify workspace requirements. Bump version to 1.0.3 and add optional development dependencies in pyproject.toml. 

Included unit tests for utility functions.